### PR TITLE
show full error

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -196,14 +196,13 @@ switch (argv._[0]) {
           })
           .catch(err => {
             process.exitCode = 1;
-            console.log(1);
             return Promise.reject(err);
           })
       })
       .catch(err => {
         // Outer catch, for compilation.
         // TODO: check Error type and respond with appropriate error code
-        console.error(err.message);
+        console.error(err);
         process.exitCode = 1;
       })
 


### PR DESCRIPTION
instead of printing "1" followed by just the error's message

before:

```
$ diesl execute -l language-openmrs.Adaptor -e tmp/expression.js -s tmp/config.json
Posting patient:
{"Name":"Foo88"}
1
getaddrinfo ENOTFOUND undefined undefined:80
```

after:

```
$ diesl execute -l language-openmrs.Adaptor -e tmp/expression.js -s tmp/config.json
Posting patient:
{"Name":"Foo88"}
{ Error: getaddrinfo ENOTFOUND undefined undefined:80
    at errnoException (dns.js:28:10)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:76:26)
  code: 'ENOTFOUND',
  errno: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'undefined',
  host: 'undefined',
  port: 80,
  response: undefined }
```