### PR TITLE
add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - '6.5.0'


### PR DESCRIPTION
I noticed github's not running the tests automatically (noticed this when I saw language-commcare, language-common, and language-dhis2 all with `npm test` failing locally).

Not sure if you've used travis before, but it's a really simple (and free for open source) way to make sure tests get run on all PRs. To configure if you want to:

Follow steps 1 & 2 of https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI%3A (sign into travis-ci.org and accept their request to set the status on commits/PRs), and then merge this to effectively complete steps 3 & 4. From then on, commits will show up with checkmarks next to them if the tests pass and xmarks if the build fails.