### PR TITLE
--test option allows for http request interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,15 @@
-Diesl (aka fn-lang, aka runner) [![Build Status](https://travis-ci.org/OpenFn/fn-lang.svg?branch=master)](https://travis-ci.org/OpenFn/fn-lang)
-=====
+# fn-lang [![Build Status](https://travis-ci.org/OpenFn/fn-lang.svg?branch=master)](https://travis-ci.org/OpenFn/fn-lang)
+A language toolkit for running OpenFn job expressions.
 
-A language toolkit for running OpenFn expressions.
-
-Clone [OpenFn-DevTools](https://github.com/OpenFn/openfn-devtools) for a quick setup environment on your machine.
-
-Check out this [how-to video](https://www.youtube.com/watch?v=aLo9xBrfdCI) on expression writing, using the hosted OpenFn Service.
-
-Features
---------
-
-* Dynamically evaluate an expression with a given language adaptor
-* Wrap an expression in an executable script
-
-Examples
---------
-
-### Execute an expression
-
-`diesl compile -l language-salesforce.Adaptor -e expression.js -s data.json`
-Returns the output to `STDOUT`, allowing you check for failure/success.
-
-### Wrap an expression in a script
-
-`diesl compile -l language-salesforce.default -d doclet.json -f expression.js`
-
-Returns a wrapped expression to `STDOUT`, allowing you check the output.
-
-```
-diesl compile -l salesforce -f expression.js -o myExpression.js
-cat state.json | node myExpression.js
-```
+Getting Started
+---------------
+Clone [openfn-devTools](https://github.com/OpenFn/openfn-devtools) for a quick setup environment on your machine.  
+Use cli.js execute (described below) to run jobs.
 
 Execute
 -------
 
-`diesl execute`
+`cli.js execute -l path/to/Adaptor -s ./tmp/state.json -e ./tmp/expression.js -o ./tmp/output.json`
 
 Used to convert an expression into an executable script.
 
@@ -44,23 +18,18 @@ Options:
 -l, --language    resolvable language/adaptor path                [required]
 -e, --expression  target expression to execute                    [required]
 -s, --state       Path to initial state file.                     [required]
--o, --output      Path to write result from expression **TODO**
+-o, --output      Path to write result from expression
+-t, --test        Intercepts and logs all HTTP requests to console
 ```
 
 Examples:
 
 Use a module in the parent folder, and pick out the `Adaptor` member.
 ```
-diesl execute -l ../language-http.Adaptor -e exp.js -s state.json
+cli.js execute -l ../language-http.Adaptor -e exp.js -s state.json
 ```
 
 Use a npm installed module, and pick out the `Adaptor` member.
 ```
-diesl execute -l language-http.Adaptor -e exp.js -s state.json
+cli.js execute -l language-http.Adaptor -e exp.js -s state.json
 ```
-
-Compile
--------
-Currently deprecated in this release.
-Execute now does compilation and execution, by unifying these behaviours
-`compile` will be reimplemented to offer deeper debugging tools.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ diesl execute -l language-http.Adaptor -e exp.js -s state.json
 
 Compile
 -------
-
 Currently deprecated in this release.
 Execute now does compilation and execution, by unifying these behaviours
 `compile` will be reimplemented to offer deeper debugging tools.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -55,6 +55,11 @@ var argv = require('yargs')
         description: 'Path to write output.'
       })
 
+      .option('t', {
+        alias: 'test',
+        description: 'test mode, no HTTP requests'
+      })
+
       .example('$0 execute -l salesforce -e foo.js -s state.json', 'Using the salesforce language pack, execute foo.js to STDOUT')
 
       .help('help')
@@ -129,12 +134,15 @@ switch (argv._[0]) {
   case 'execute':
 
     const Execute = require('./execute');
-    const { modulePath, getModule, readFile, writeJSON, formatCompileError } = require('./utils');
+    const { modulePath, getModule, readFile, writeJSON, formatCompileError, interceptRequests } = require('./utils');
 
     const Compile = require('./compile');
     const { verify, wrapRootExpressions, callFunction, wrapIIFE } = require('./compile/transforms');
 
     try {
+
+      if (argv.test) { interceptRequests() };
+
       // TODO: move this into the Promise chain and create exception handler.
       const Adaptor = getModule(modulePath(argv.language));
 
@@ -150,6 +158,7 @@ switch (argv._[0]) {
         // need this to support an old job written by TNS.
         parseInt,
         JSON,
+        testMode: (argv.test),
         Promise
       }, Adaptor);
 

--- a/lib/execute.js
+++ b/lib/execute.js
@@ -11,7 +11,7 @@ function Execute({ expression, state, sandbox }) {
   let context = vm.createContext(Object.assign({ state, Promise, console }, sandbox));
 
   return vm.runInContext(expression, context);
-  
+
 }
 
 module.exports = Execute

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 
 function modulePath(str) {
   try {
-    let [ __, path, moduleName, version, memberName ] = 
+    let [ __, path, moduleName, version, memberName ] =
       str.match(/^([.]{0,2}[\/\w-]*\/)*([\w\-]+)(-v?[\d\.]*)?(?:\.)?(\w+)?$/)
 
     isRelative = !!( path && path.match(/\./) )
@@ -73,8 +73,34 @@ function formatCompileError(code, error) {
     Array(end.column - start.column + 1).join("^"),
     "\n" + error.message
   ].join('')
-  
+
 }
 
+function interceptRequests() {
+  console.log("Test mode enabled...")
+  var Mitm = require("mitm")
+  var mitm = Mitm()
+  mitm.on("request", function(req, res) {
+    console.log("Intercepted HTTP Request...");
+    console.log(`Method: ${req.method}`);
+    console.log(`URL: ${req.url}`);
+    console.log(`Headers: ${JSON.stringify(req.headers, null, 2)}`);
+    var body = "";
+    req.on('readable', function() {
+      body += req.read();
+    });
+    req.on('end', function() {
+      try {
+        jsonBody = JSON.parse(body)
+        console.log(JSON.stringify(jsonBody, null, 2))
+      } catch (e) {
+        console.log(body)
+      }
+      res.write("What is real? How do you define 'real'? If you're talking about what you can feel, what you can smell, what you can taste and see, then 'real' is simply electrical signals interpreted by your brain.");
+      res.end();
+    });
+  })
+}
 
-module.exports = { modulePath, getModule, readFile, writeJSON, formatCompileError };
+module.exports = { modulePath, getModule, readFile, writeJSON,
+  interceptRequests, formatCompileError };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ast-types": "^0.9.0",
     "doclet-query": "github:openfn/doclet-query#v0.1.0",
     "estemplate": "^0.5.1",
+    "mitm": "^1.3.2",
     "recast": "^0.11.13",
     "yargs": "^3.30.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "diesl",
-  "version": "0.5.6",
+  "name": "fn-lang",
+  "version": "0.6.0",
   "description": "OpenFn Language Toolchain",
   "main": "index.js",
   "bin": "./lib/cli.js",


### PR DESCRIPTION
@stuartc , this PR allows cli users (and maybe hosted service users, but running inside core is totally untested!) to specify a `--test` option that intercepts all HTTP requests, logs the url, headers, and body of the request, then sends back a generic 200:OK.

This gets around having to keep two separate versions of each adaptor (Adapator and FakeAdaptor) and while it doesn't work in full for language-salesforce, just about every other language-package we've got uses basic HTTP requests so it's quite handy.