### PR TITLE
move sandbox population to utils

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -76,24 +76,13 @@ switch (argv._[0]) {
 
     try {
 
-      const { modulePath, getModule, readFile, writeJSON, formatCompileError } = require('./utils');
+      const { modulePath, getModule, readFile, writeJSON, formatCompileError, makeSandbox } = require('./utils');
 
       const Compile = require('./compile');
       const { verify, wrapRootExpressions, callFunction, wrapIIFE } = require('./compile/transforms');
       const Adaptor = getModule(modulePath(argv.language));
 
-      const sandbox = Object.assign({
-        Array,
-        console,
-        Date,
-        JSON,
-        Math,
-        Number,
-        parseInt, // need this to support an old job written by TNS.
-        Promise,
-        setTimeout,
-        String,
-      }, Adaptor);
+      const sandbox = makeSandbox(Adaptor, argv);
 
       const transforms = [
         verify({ sandbox }),
@@ -135,7 +124,7 @@ switch (argv._[0]) {
   case 'execute':
 
     const Execute = require('./execute');
-    const { modulePath, getModule, readFile, writeJSON, formatCompileError, interceptRequests } = require('./utils');
+    const { modulePath, getModule, readFile, writeJSON, formatCompileError, interceptRequests, makeSandbox } = require('./utils');
 
     const Compile = require('./compile');
     const { verify, wrapRootExpressions, callFunction, wrapIIFE } = require('./compile/transforms');
@@ -150,19 +139,7 @@ switch (argv._[0]) {
       // Make a sandbox used by both Execute and the `verify` transform.
       // Expressions will have access to `console`, `Promise` and the
       // adaptor functions (spread).
-      const sandbox = Object.assign({
-        Array,
-        console,
-        Date,
-        JSON,
-        Math,
-        Number,
-        parseInt, // need this to support an old job written by TNS.
-        Promise,
-        setTimeout,
-        String,
-        testMode: (argv.test),
-      }, Adaptor);
+      const sandbox = makeSandbox(Adaptor, argv);
 
       const transforms = [
         verify({ sandbox }),

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,5 +102,24 @@ function interceptRequests() {
   })
 }
 
+function makeSandbox(adaptor, argv) {
+  return Object.assign(
+    {
+      Array,
+      console,
+      Date,
+      JSON,
+      Math,
+      Number,
+      parseInt, // need this to support an old job written by TNS.
+      Promise,
+      setTimeout,
+      String,
+      testMode: argv.test,
+    },
+    adaptor
+  );
+}
+
 module.exports = { modulePath, getModule, readFile, writeJSON,
-  interceptRequests, formatCompileError };
+  interceptRequests, formatCompileError, makeSandbox };


### PR DESCRIPTION
shifts the population of the sanbox (JS globals, mostly) into Utils so we can keep a list of available globals without repeating ourselves.