### PR TITLE
Running expressions programmatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /tmp
+*.sw[mnop]

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -84,15 +84,12 @@ var argv = require('yargs')
   .alias('h', 'help')
   .epilog('OpenFn 2016').argv;
 
-const Compile = require('./compile');
-const Execute = require('./execute');
-
 const {
-  verify,
-  wrapRootExpressions,
-  callFunction,
-  wrapIIFE,
-} = require('./compile/transforms');
+  Compile,
+  Execute,
+  transforms: { defaultTransforms, verify },
+  sandbox: { buildSandbox, VMGlobals },
+} = require('.');
 
 const {
   modulePath,
@@ -101,55 +98,33 @@ const {
   writeJSON,
   formatCompileError,
   interceptRequests,
-  disabledConsole,
+  getModuleVersion,
 } = require('./utils');
-
-const { VM } = require('vm2');
-const globals = new VM({}).run(
-  `Object.getOwnPropertyNames(this).reduce((obj, item) => {
-    obj[item] = this[item];
-    return obj;
-  }, {});`
-);
-
-// TODO: move this into the Promise chain and create exception handler.
-const Adaptor = getModule(modulePath(argv.language));
-
-// Assign extensions which will be added to VM2's sandbox, used by both Execute
-// and the `verify` transform in Compile.
-const extensions = Object.assign(
-  {
-    console: argv.noConsole ? disabledConsole : console, // --nc or --noConsole
-    testMode: argv.test, // --t or --test
-    setTimeout, // We allow as Erlang will handle killing long-running VMs.
-  },
-  Adaptor
-);
 
 switch (argv._[0]) {
   case 'compile':
     try {
-      const transforms = [
-        verify({ sandbox: Object.assign(globals, extensions) }),
-        wrapRootExpressions('execute'),
-        callFunction('execute', 'state'),
-        // TODO: wrap in Promise IIFE, to ensure Executes interface is
-        // always the same - conforming all errors.
-        wrapIIFE(),
-      ];
+      const Adaptor = getModule(modulePath(argv.language));
+
+      const sandbox = buildSandbox({
+        noConsole: argv.noConsole,
+        testMode: argv.test,
+        extensions: [Adaptor],
+      });
 
       readFile(argv.expression)
         .then(code => {
-          const compile = new Compile(code, transforms);
+          const compile = new Compile(code, [
+            ...defaultTransforms,
+            verify({ sandbox: { ...sandbox, ...VMGlobals } }),
+          ]);
 
           if (compile.errors.length > 0) {
-            compile.errors
-              .map(error => {
-                return formatCompileError(code, error);
-              })
-              .map(error => {
-                console.log(error);
-              });
+            console.error(
+              compile.errors
+                .map(err => formatCompileError(code, err))
+                .join('\n')
+            );
 
             return Promise.reject(new Error('Compilation failed.'));
           }
@@ -171,18 +146,7 @@ switch (argv._[0]) {
     break;
 
   case 'execute':
-    const fs = require('fs');
-    let adaptorVersion;
-    try {
-      const path = argv.language;
-      const rawdata = fs.readFileSync(
-        path.substring(0, path.lastIndexOf('Adaptor') - 1) + '/package.json'
-      );
-      const package = JSON.parse(rawdata);
-      adaptorVersion = `${package.name}#v${package.version}`;
-    } catch (error) {
-      adaptorVersion = argv.language;
-    }
+    const adaptorVersion = getModuleVersion(argv.language);
 
     const debug = `│ ◰ ◱ ◲ ◳  OpenFn/core ~ ${adaptorVersion} (Node ${process.version}) │`;
     console.log('╭' + '─'.repeat(debug.length - 2) + '╮');
@@ -194,28 +158,28 @@ switch (argv._[0]) {
         interceptRequests();
       }
 
-      const transforms = [
-        verify({ sandbox: Object.assign(globals, extensions) }),
-        wrapRootExpressions('execute'),
-        callFunction('execute', 'state'),
-        // TODO: wrap in Promise IIFE, to ensure Executes interface is
-        // always the same - conforming all errors.
-        wrapIIFE(),
-      ];
+      const Adaptor = getModule(modulePath(argv.language));
+
+      const sandbox = buildSandbox({
+        noConsole: argv.noConsole,
+        testMode: argv.test,
+        extensions: [Adaptor],
+      });
 
       Promise.all([
         readFile(argv.state).then(JSON.parse),
         readFile(argv.expression).then(code => {
-          const compile = new Compile(code, transforms);
+          const compile = new Compile(code, [
+            ...defaultTransforms,
+            verify({ sandbox: { ...sandbox, ...VMGlobals } }),
+          ]);
 
           if (compile.errors.length > 0) {
-            compile.errors
-              .map(error => {
-                return formatCompileError(code, error);
-              })
-              .map(error => {
-                console.log(error);
-              });
+            console.error(
+              compile.errors
+                .map(err => formatCompileError(code, err))
+                .join('\n')
+            );
 
             return Promise.reject(new Error('Compilation failed.'));
           }
@@ -223,11 +187,10 @@ switch (argv._[0]) {
           return compile.toString();
         }),
       ])
-
         .then(([state, expression]) => {
           // Break comment if you want to see the expression prior to execution.
           // console.log(expression);
-          return Execute({ expression, state, extensions })
+          return Execute({ expression, state, sandbox })
             .then(state => {
               // TODO: stat path and check is writable before running expression
               if (argv.output) {

--- a/lib/compile/transforms.js
+++ b/lib/compile/transforms.js
@@ -128,7 +128,7 @@ function wrapRootExpressions(ident) {
 function callFunction(call, ident) {
   return ast => {
     types.visit(ast, {
-      visitCallExpression: function(path) {
+      visitCallExpression: function (path) {
         var node = path.node;
 
         // If a callExpression's callee is also a callExpression
@@ -169,4 +169,16 @@ function wrapIIFE() {
   };
 }
 
-module.exports = { verify, wrapRootExpressions, callFunction, wrapIIFE };
+const defaultTransforms = [
+  wrapRootExpressions('execute'),
+  callFunction('execute', 'state'),
+  wrapIIFE(),
+];
+
+module.exports = {
+  verify,
+  wrapRootExpressions,
+  callFunction,
+  wrapIIFE,
+  defaultTransforms,
+};

--- a/lib/execute.js
+++ b/lib/execute.js
@@ -1,10 +1,8 @@
 const { VM } = require('vm2');
 
-// Handler for wrapping a compiled expression in an IIFE and a Promise,
-// ensuring an executed expression meets the expected return type (Promise)
-// and is executed in an isolated enviroment with all language pack functions
-// available on the root.
-function Execute({ expression, state, extensions }) {
+// Executes a given expression in a sandbox, adding state in to the global
+// object.
+function Execute({ expression, state, sandbox }) {
   if (!expression) {
     throw new Error('Cannot execute without an expression.');
   }
@@ -13,7 +11,7 @@ function Execute({ expression, state, extensions }) {
   }
 
   return new VM({
-    sandbox: Object.assign({ state }, extensions),
+    sandbox: Object.assign({ state }, sandbox),
   }).run(expression);
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,8 @@
+const Compile = require('./compile');
+const Execute = require('./execute');
+const transforms = require('./compile/transforms');
+const sandbox = require('./sandbox');
+
+module.exports = {
+  Compile, Execute, transforms, sandbox
+}

--- a/lib/sandbox/index.js
+++ b/lib/sandbox/index.js
@@ -1,0 +1,27 @@
+const { VM } = require('vm2');
+const { disabledConsole } = require('../utils');
+
+// Get all the globals from an empty VM2 sandbox
+const VMGlobals = new VM({}).run(
+  `Object.getOwnPropertyNames(this).reduce((obj, item) => {
+    obj[item] = this[item];
+    return obj;
+  }, {});`
+);
+
+function buildSandbox(
+  opts = { noConsole: false, testMode: false, extensions: [] }
+) {
+  // Create an object to be used as an extension to the VMs root object.
+
+  return Object.assign(
+    {
+      console: opts.noConsole ? disabledConsole : console, // --nc or --noConsole
+      testMode: opts.testMode, // --t or --test
+      setTimeout, // We allow as Erlang will handle killing long-running VMs.
+    },
+    ...opts.extensions
+  );
+}
+
+module.exports = { buildSandbox, VMGlobals };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,8 +39,20 @@ function getModule({ path, memberName, isRelative }) {
   return module;
 }
 
+function getModuleVersion(path) {
+  try {
+    const packageJson = fs.readFileSync(
+      path.substring(0, path.lastIndexOf('Adaptor') - 1) + '/package.json'
+    );
+    const package = JSON.parse(packageJson);
+    return `${package.name}#v${package.version}`;
+  } catch (error) {
+    return path;
+  }
+}
+
 // Generic Promise wrapper for fs.readFile.
-function readFile(path, options = 'utf8') {
+async function readFile(path, options = 'utf8') {
   return new Promise((resolve, reject) => {
     fs.readFile(path, options, (err, data) => {
       if (err) reject(err);
@@ -50,7 +62,12 @@ function readFile(path, options = 'utf8') {
 }
 
 // Serialise and write object to JSON file.
-function writeJSON(path, obj, options = 'utf8') {
+async function readJSON(path, options = 'utf8') {
+  return JSON.parse(await readFile(...arguments));
+}
+
+// Serialise and write object to JSON file.
+async function writeJSON(path, obj, options = 'utf8') {
   return new Promise((resolve, reject) => {
     try {
       let data = JSON.stringify(obj, null, 2);
@@ -130,11 +147,13 @@ const disabledConsole = {
 };
 
 module.exports = {
-  modulePath,
-  getModule,
-  readFile,
-  writeJSON,
-  interceptRequests,
-  formatCompileError,
   disabledConsole,
+  formatCompileError,
+  getModule,
+  getModuleVersion,
+  interceptRequests,
+  modulePath,
+  readFile,
+  readJSON,
+  writeJSON,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1396,6 +1396,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "deep-eql": "0.1.3",
     "eslint": ">=4.18.2",
-    "mocha": "^7.0"
+    "mocha": "^7.0",
+    "prettier": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/OpenFn/core.git"
   },
-  "main": "index.js",
+  "main": "./lib/index.js",
   "bin": "./lib/cli.js",
   "scripts": {
     "test": "mocha --recursive",

--- a/test/execute.test.js
+++ b/test/execute.test.js
@@ -21,7 +21,7 @@ describe("Execute", () => {
       let result = Execute({
         expression: `add(1)(state)`,
         state: 1,
-        extensions: { add: num => state => { return state + num } }
+        sandbox: { add: num => state => { return state + num } }
       })
       assert.equal(result, 2)
 


### PR DESCRIPTION
This marks the first of a few larger changes allowing core to used
programmatically from Node - instead of via the command line.

I would say that it's not the last set of changes around this, but I'm hoping this 
offers something between crazy amounts of copy pasting and a 'single-call' solution.

@magp18 got the ball rolling on this, and thanks go to him for showing how important this is.

I think it's worth pursuing further abstracting to make this easier to use - as there
are several moving parts involved and I'm hesitant to hide all the bits involved
before we get to see how people will use it. So feedback is appreciated!

There is an updated version of the README [over here](https://github.com/OpenFn/core/commit/2419e9d7eaf3aaf4cdd15b80b613793deb9e7b93?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) containing an example use on
how to run an expression without the CLI. 

- Abstract getModuleVersion to utils
- Make lib/index the module root, exporting submodules
- Change 'extensions' to sandbox on Execute
- export list of 'defaultTransforms'
- Refactored cli.js
- Abstract sandbox building into own file