### PR TITLE
writeJSON uses safeStringify(...)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const safeStringify = require('fast-safe-stringify');
 
 function modulePath(str) {
   try {
@@ -70,7 +71,7 @@ async function readJSON(path, options = 'utf8') {
 async function writeJSON(path, obj, options = 'utf8') {
   return new Promise((resolve, reject) => {
     try {
-      let data = JSON.stringify(obj, null, 2);
+      let data = safeStringify(obj, null, 2);
       fs.writeFile(path, data, options, err => {
         if (err) reject(err);
         resolve();
@@ -102,7 +103,7 @@ function interceptRequests() {
     console.log('Intercepted HTTP Request...');
     console.log(`Method: ${req.method}`);
     console.log(`URL: ${req.url}`);
-    console.log(`Headers: ${JSON.stringify(req.headers, null, 2)}`);
+    console.log(`Headers: ${safeStringify(req.headers, null, 2)}`);
     var body = '';
     req.on('readable', function () {
       body += req.read();
@@ -110,7 +111,7 @@ function interceptRequests() {
     req.on('end', function () {
       try {
         jsonBody = JSON.parse(body);
-        console.log(JSON.stringify(jsonBody, null, 2));
+        console.log(safeStringify(jsonBody, null, 2));
       } catch (e) {
         console.log(body);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/core",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -548,6 +548,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/core",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "description": "The central job processing program used in the OpenFn platform.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ast-types": "^0.9.0",
     "doclet-query": "github:openfn/doclet-query#v0.1.0",
     "estemplate": "^0.5.1",
+    "fast-safe-stringify": "^2.0.7",
     "mitm": "^1.3.2",
     "recast": "0.19.0",
     "vm2": "^3.9.2",


### PR DESCRIPTION
When dealing with http request responses from things like `axios` or the `request` module, we often hit ciruclar reference errors in JSON.stringify to write out `output.json`. This PR address that issue by using `safeStringify(...)` from https://www.npmjs.com/package/fast-safe-stringify .

At 5M downloads per week it looks like a fairly well supported module.