### PR TITLE
Allow NPM style language pack specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 8
-  - 10
   - 12
+  - 14

--- a/lib/cli/compile-command.js
+++ b/lib/cli/compile-command.js
@@ -5,20 +5,27 @@ const {
 } = require('..');
 
 const {
-  getModuleDetails,
+  safeResolve,
   readFile,
   formatCompileError,
 } = require('../utils');
 
 function handler(argv) {
   try {
-    const moduleDetails = getModuleDetails(argv.language);
-    const adaptor = require(argv.language);
+    const adaptorPath =
+      safeResolve(argv.language) ||
+      safeResolve(argv.language, { paths: ['.'] });
+
+    if (!adaptorPath) {
+      throw new Error(`Cannot find module '${argv.language}'.`);
+    }
+
+    const adaptor = require(adaptorPath);
 
     const sandbox = buildSandbox({
       noConsole: argv.noConsole,
       testMode: argv.test,
-      extensions: [adaptor],
+      extensions: [adaptor.Adaptor || adaptor],
     });
 
     readFile(argv.expression)

--- a/lib/cli/compile-command.js
+++ b/lib/cli/compile-command.js
@@ -5,20 +5,20 @@ const {
 } = require('..');
 
 const {
-  modulePath,
-  getModule,
+  getModuleDetails,
   readFile,
   formatCompileError,
 } = require('../utils');
 
 function handler(argv) {
   try {
-    const Adaptor = getModule(modulePath(argv.language));
+    const moduleDetails = getModuleDetails(argv.language);
+    const adaptor = require(argv.language);
 
     const sandbox = buildSandbox({
       noConsole: argv.noConsole,
       testMode: argv.test,
-      extensions: [Adaptor],
+      extensions: [adaptor],
     });
 
     readFile(argv.expression)

--- a/lib/cli/execute-command.js
+++ b/lib/cli/execute-command.js
@@ -6,32 +6,47 @@ const {
 } = require('..');
 
 const {
-  modulePath,
-  getModule,
+  safeResolve,
   readFile,
   writeJSON,
   formatCompileError,
   interceptRequests,
-  getModuleVersion,
+  getModuleDetails,
   addDebugLogs,
 } = require('../utils');
 
 function handler(argv) {
-  const adaptorVersion = getModuleVersion(argv.language);
-
-  addDebugLogs(adaptorVersion);
-
   try {
     if (argv.test) {
       interceptRequests();
     }
 
-    const Adaptor = getModule(modulePath(argv.language));
+    const moduleDetails = getModuleDetails(argv.language) || {
+      version: 'unknown',
+    };
+
+    addDebugLogs(moduleDetails);
+
+    // We try and resolve the location of the module entry point by first trying
+    // with the default lookups/NODE_PATH env var, then fall back to looking in
+    // local directory.
+    // This is to allow loading language packs from both a node_modules folder
+    // or relative paths. Working around that a relative path is considered
+    // from _this_ file - and not from the cwd where the path was given.
+    const adaptorPath =
+      safeResolve(argv.language) ||
+      safeResolve(argv.language, { paths: ['.'] });
+
+    if (!adaptor) {
+      throw new Error(`Cannot find module '${argv.language}' fdgdfgf`);
+    }
+
+    const adaptor = require(adaptorPath);
 
     const sandbox = buildSandbox({
       noConsole: argv.noConsole,
       testMode: argv.test,
-      extensions: [Adaptor],
+      extensions: [adaptor],
     });
 
     Promise.all([

--- a/lib/cli/execute-command.js
+++ b/lib/cli/execute-command.js
@@ -37,8 +37,8 @@ function handler(argv) {
       safeResolve(argv.language) ||
       safeResolve(argv.language, { paths: ['.'] });
 
-    if (!adaptor) {
-      throw new Error(`Cannot find module '${argv.language}' fdgdfgf`);
+    if (!adaptorPath) {
+      throw new Error(`Cannot find module '${argv.language}'.`);
     }
 
     const adaptor = require(adaptorPath);
@@ -46,7 +46,7 @@ function handler(argv) {
     const sandbox = buildSandbox({
       noConsole: argv.noConsole,
       testMode: argv.test,
-      extensions: [adaptor],
+      extensions: [adaptor.Adaptor || adaptor],
     });
 
     Promise.all([

--- a/lib/cli/execute-command.js
+++ b/lib/cli/execute-command.js
@@ -21,9 +21,7 @@ function handler(argv) {
       interceptRequests();
     }
 
-    const moduleDetails = getModuleDetails(argv.language) || {
-      version: 'unknown',
-    };
+    const moduleDetails = getModuleDetails(argv.language);
 
     addDebugLogs(moduleDetails);
 

--- a/lib/cli/execute-command.js
+++ b/lib/cli/execute-command.js
@@ -73,7 +73,13 @@ function handler(argv) {
           .then(state => {
             // TODO: stat path and check is writable before running expression
             if (argv.output) {
-              return writeJSON(argv.output, state);
+              if (['object', 'string', 'number'].includes(typeof state)) {
+                return writeJSON(argv.output, state);
+              } else {
+                throw new Error(
+                  `Could not write state to file, type must be serializable. Got '${typeof state}'`
+                );
+              }
             }
             return state;
           })

--- a/lib/compile/transforms.js
+++ b/lib/compile/transforms.js
@@ -42,7 +42,7 @@ function verify(opts) {
 
     types.visit(ast, {
       // This method will be called for any node with .type "CallExpression":
-      visitCallExpression: function(path) {
+      visitCallExpression: function (path) {
         var node = path.node;
 
         // If a callExpression's callee is also a callExpression
@@ -101,7 +101,7 @@ function wrapRootExpressions(ident) {
     ast.rootExpressions = [];
 
     types.visit(ast, {
-      visitCallExpression: function(path) {
+      visitCallExpression: function (path) {
         var node = path.node;
 
         ast.rootExpressions.push(node);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,54 +1,41 @@
 const fs = require('fs');
 const safeStringify = require('fast-safe-stringify');
+const path = require('path');
 
-function modulePath(str) {
-  try {
-    let [__, path, moduleName, version, memberName] = str.match(
-      process.platform === 'win32'
-        ? /^([\w:]{0,2}[.]{0,2}[\/\w-]*\/)*([\w\-]+)(-v?[\d\.]*)?(?:\.)?(\w+)?$/
-        : /^([.]{0,2}[\/\w-]*\/)*([\w\-]+)(-v?[\d\.]*)?(?:\.)?(\w+)?$/
-    );
-
-    isRelative = !!(path && path.match(/\./));
-    version = version || '';
-    path = (path || '') + moduleName + version.replace(/.$/, '');
-    memberName = memberName || null;
-
-    return { path, memberName, isRelative };
-  } catch (e) {
-    console.log(e);
-    throw new Error("Can't resolve module details");
-  }
+function getPackageJson(path) {
+  const packageJson = fs.readFileSync(path);
+  return JSON.parse(packageJson);
 }
 
-// Given a parsed module path, require the module either relatively or
-// directly (normal nodejs lookup) and return the member if necessary.
-function getModule({ path, memberName, isRelative }) {
-  let module;
+function getModuleDetails(languagePack) {
+  const lookupPaths = [
+    languagePack + '/package.json',
+    path.normalize(`${languagePack}/../package.json`),
+    path.normalize(`${languagePack}/../../package.json`),
+  ];
 
-  if (isRelative) {
-    module = require(process.cwd() + '/' + path);
-  } else {
-    module = require(path);
+  for (let i = 0; i < lookupPaths.length; i++) {
+    const resolvedPath = safeResolve(lookupPaths[i]);
+    console.log(lookupPaths[i], resolvedPath);
+    if (resolvedPath) {
+      return getPackageJson(resolvedPath);
+    }
   }
 
-  // Module path is `module-name.member`.
-  if (memberName) {
-    return module[memberName];
-  }
-
-  return module;
+  return null;
 }
 
-function getModuleVersion(path) {
+// require.resolve wrapped in an error handler, so that we can call successsively
+// to locate the package.json for a language-pack
+function safeResolve(request, options) {
   try {
-    const packageJson = fs.readFileSync(
-      path.substring(0, path.lastIndexOf('Adaptor') - 1) + '/package.json'
-    );
-    const package = JSON.parse(packageJson);
-    return `${package.name}#v${package.version}`;
+    return require.resolve(request, options);
   } catch (error) {
-    return path;
+    if (error?.code == 'MODULE_NOT_FOUND') {
+      return false;
+    }
+
+    throw err;
   }
 }
 
@@ -147,9 +134,10 @@ const disabledConsole = {
   },
 };
 
-function addDebugLogs(adaptorVersion) {
-  const thisPack = require('../package.json');
-  const debug1 = `│ ◲ ◱  ${thisPack.name}#v${thisPack.version} (Node.js ${process.version}) │`;
+function addDebugLogs(languagePackage) {
+  const corePackage = require('../package.json');
+  const adaptorVersion = languagePackage.version;
+  const debug1 = `│ ◲ ◱  ${corePackage.name}#v${corePackage.version} (Node.js ${process.version}) │`;
   const debug2 =
     '│ ◳ ◰ ' +
     ' '.repeat(debug1.length - adaptorVersion.length - 9) +
@@ -162,14 +150,13 @@ function addDebugLogs(adaptorVersion) {
 }
 
 module.exports = {
+  addDebugLogs,
   disabledConsole,
   formatCompileError,
-  getModule,
-  getModuleVersion,
   interceptRequests,
-  modulePath,
+  getModuleDetails,
   readFile,
   readJSON,
+  safeResolve,
   writeJSON,
-  addDebugLogs,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -136,7 +136,7 @@ const disabledConsole = {
 
 function addDebugLogs(languagePackage) {
   const corePackage = require('../package.json');
-  const adaptorVersion = languagePackage.version;
+  const adaptorVersion = `${languagePackage.name}@${languagePackage.version}`;
   const debug1 = `│ ◲ ◱  ${corePackage.name}#v${corePackage.version} (Node.js ${process.version}) │`;
   const debug2 =
     '│ ◳ ◰ ' +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,18 +8,11 @@ function getPackageJson(path) {
 }
 
 function getModuleDetails(languagePack) {
-  const lookupPaths = [
-    languagePack + '/package.json',
-    path.normalize(`${languagePack}/../package.json`),
-    path.normalize(`${languagePack}/../../package.json`),
-  ];
+  const lookupPath = languagePack + '/package.json';
 
-  for (let i = 0; i < lookupPaths.length; i++) {
-    const resolvedPath = safeResolve(lookupPaths[i]);
-    console.log(lookupPaths[i], resolvedPath);
-    if (resolvedPath) {
-      return getPackageJson(resolvedPath);
-    }
+  const resolvedPath = safeResolve(lookupPath);
+  if (resolvedPath) {
+    return getPackageJson(resolvedPath);
   }
 
   return null;
@@ -136,7 +129,9 @@ const disabledConsole = {
 
 function addDebugLogs(languagePackage) {
   const corePackage = require('../package.json');
-  const adaptorVersion = `${languagePackage.name}@${languagePackage.version}`;
+  const adaptorVersion = languagePackage
+    ? `${languagePackage.name}@${languagePackage.version}`
+    : `unknown`;
   const debug1 = `│ ◲ ◱  ${corePackage.name}#v${corePackage.version} (Node.js ${process.version}) │`;
   const debug2 =
     '│ ◳ ◰ ' +

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,11 +31,11 @@ function safeResolve(request, options) {
   try {
     return require.resolve(request, options);
   } catch (error) {
-    if (error?.code == 'MODULE_NOT_FOUND') {
+    if (error.code == 'MODULE_NOT_FOUND') {
       return false;
     }
 
-    throw err;
+    throw error;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openfn/core",
-  "version": "1.3.13",
+  "version": "1.4.0",
   "description": "The central job processing program used by OpenFn integration tools.",
   "repository": {
     "type": "git",

--- a/test/execute.test.js
+++ b/test/execute.test.js
@@ -1,30 +1,31 @@
 const assert = require('assert');
 const Execute = require('../lib/execute');
 
-describe("Execute", () => {
-  it("expects an expression", () => {
-    assert.throws(
-      () => { Execute({}) },
-      /Cannot execute without an expression./
-    )
-  })
+describe('Execute', () => {
+  it('expects an expression', () => {
+    assert.throws(() => {
+      Execute({});
+    }, /Cannot execute without an expression./);
+  });
 
-  it("expects an initial state", () => {
-    assert.throws(
-      () => { Execute({ expression: "foo" }) },
-      /Cannot execute without an initial state./
-    )
-  })
+  it('expects an initial state', () => {
+    assert.throws(() => {
+      Execute({ expression: 'foo' });
+    }, /Cannot execute without an initial state./);
+  });
 
-  describe("when given an expression and state", () => {
-    it("returns", () => {
+  describe('when given an expression and state', () => {
+    it('returns', () => {
       let result = Execute({
         expression: `add(1)(state)`,
         state: 1,
-        sandbox: { add: num => state => { return state + num } }
-      })
-      assert.equal(result, 2)
-
-    })
-  })
-})
+        sandbox: {
+          add: num => state => {
+            return state + num;
+          },
+        },
+      });
+      assert.equal(result, 2);
+    });
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,75 +1,28 @@
 const assert = require('assert');
-const { modulePath, writeJSON, readFile, formatCompileError } = require('../lib/utils');
+const {
+  modulePath,
+  writeJSON,
+  readFile,
+  formatCompileError,
+} = require('../lib/utils');
 
-describe("Utils", () => {
-
-  it(".modulePath", () => {
-
-    let matches;
-
-    matches = modulePath("language-salesforce")
-    assert.deepEqual(matches, {
-      path: 'language-salesforce',
-      memberName: null,
-      isRelative: false
-    })
-
-    matches = modulePath("language-salesforce.Adaptor")
-    assert.deepEqual(matches, {
-      path: 'language-salesforce',
-      memberName: 'Adaptor',
-      isRelative: false
-    })
-
-    matches = modulePath("./language-salesforce.Adaptor")
-    assert.deepEqual(matches, {
-      path: './language-salesforce',
-      memberName: 'Adaptor',
-      isRelative: true
-    })
-
-    matches = modulePath("./path/to/language-salesforce.Adaptor")
-    assert.deepEqual(matches, {
-      path: './path/to/language-salesforce',
-      memberName: 'Adaptor',
-      isRelative: true
-    })
-
-    matches = modulePath("./path/to/language-salesforce-v1.0.0.Adaptor")
-    assert.deepEqual(matches, {
-      path: './path/to/language-salesforce-v1.0.0',
-      memberName: 'Adaptor',
-      isRelative: true
-    })
-
-    matches = modulePath("/path/to/language-salesforce-v1.0.0.Adaptor")
-    assert.deepEqual(matches, {
-      path: '/path/to/language-salesforce-v1.0.0',
-      memberName: 'Adaptor',
-      isRelative: false
-    })
-
-  })
-
-  it(".writeJSON", () => {
-    return writeJSON('/tmp/output.json', {a: 1})
+describe('Utils', () => {
+  it('.writeJSON', () => {
+    return writeJSON('/tmp/output.json', { a: 1 })
       .then(() => readFile('/tmp/output.json'))
-      .then((str) => assert.deepEqual({a: 1}, JSON.parse(str)))
-  })
+      .then(str => assert.deepEqual({ a: 1 }, JSON.parse(str)));
+  });
 
-  it(".formatCompileError", () => {
-    let expected = [
-    "Line 1: foo()",
-    "        ^^^^^",
-    "Bad!"
-    ].join("\n")
+  it('.formatCompileError', () => {
+    let expected = ['Line 1: foo()', '        ^^^^^', 'Bad!'].join('\n');
 
-    let result = formatCompileError("foo()", {
-      node: { loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } } },
-      message: "Bad!"
-    })
+    let result = formatCompileError('foo()', {
+      node: {
+        loc: { start: { line: 1, column: 0 }, end: { line: 1, column: 5 } },
+      },
+      message: 'Bad!',
+    });
 
     assert.equal(expected, result);
-  })
-})
-
+  });
+});


### PR DESCRIPTION
**BREAKING CHANGES**

- `language-pack.Adaptor` style will no longer work
  use `language-pack/Adaptor` or `language-pack` if the default export
  of the module is `Adaptor`.

_still to do_

- Tests for the new `getModuleDetails` function
- Abstract the double `safeResolve` in the execute cli handler with some
  better explanations.

Closes #23