### PR TITLE
Security updates

### DIFF
--- a/lib/compile/transforms.js
+++ b/lib/compile/transforms.js
@@ -169,7 +169,20 @@ function wrapIIFE() {
   };
 }
 
+// Class statements are now illegal in expressions, as they may expose
+// security vulnerabilities. See https://github.com/OpenFn/core/issues/47
+function banClasses() { 
+  return ast => {
+    types.visit(ast, {
+      visitClassDeclaration: () => {
+        throw new Error('Illegal class statement')
+      }
+    });
+  }
+}
+
 const defaultTransforms = [
+  banClasses(),
   wrapRootExpressions('execute'),
   callFunction('execute', 'state'),
   wrapIIFE(),
@@ -180,5 +193,6 @@ module.exports = {
   wrapRootExpressions,
   callFunction,
   wrapIIFE,
+  banClasses,
   defaultTransforms,
 };

--- a/test/compile/index.test.js
+++ b/test/compile/index.test.js
@@ -5,6 +5,7 @@ const {
   wrapRootExpressions,
   callFunction,
   wrapIIFE,
+  banClasses,
 } = require('../../lib/compile/transforms');
 
 describe('Compile', () => {
@@ -78,6 +79,14 @@ describe('Transforms', () => {
           '})();',
         ].join('\n')
       );
+    });
+  });
+
+  describe('banClasses', () => {
+    it('throws an error if a class statement is detected', () => {
+      assert.throws(() => {
+        new Compile('class Naughty {}', [banClasses()]);
+      }, /Illegal class statement/);
     });
   });
 });

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const Execute = require('../lib/execute');
+const Compile = require('../lib/compile');
+const { defaultTransforms } = require('../lib/compile/transforms')
 
 describe('security', () => {
   it('should allow access to the console object', () => {
@@ -26,4 +28,15 @@ describe('security', () => {
       /require is not defined/
     );
   });
+
+  it('should not compile a job with a class', () => {
+    const code = `fn(() => {
+      class Naughty {}
+    })`
+    assert.throws(() => {
+      new Compile(code, [
+        ...defaultTransforms,
+      ]);
+    }, /Illegal class statement/);
+  })
 });

--- a/test/security.test.js
+++ b/test/security.test.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+const Execute = require('../lib/execute');
+
+describe('security', () => {
+  it('should allow access to the console object', () => {
+    const result = Execute({
+      expression: 'fn(() => { console.log(">> jam"); return 1 });',
+      state: {},
+      sandbox: {
+        fn: f => f(),
+      },
+    });
+    assert.equal(result, 1);
+  });
+
+  it('should not allow access to the process object', () => {
+    assert.throws(
+      () => Execute({ expression: 'process.env', state: {} }),
+      /process is not defined/
+    );
+  });
+
+  it('should not allow access to require', () => {
+    assert.throws(
+      () => Execute({ expression: 'require("node:fs")', state: {} }),
+      /require is not defined/
+    );
+  });
+});


### PR DESCRIPTION
This PR addresses two recent security vulnerabilities (#47) with the following changes:

* Adds a few unit tests to cover the cases
* Bans classes from job code

The first vulnerability requires users to `require('node:util')`, and allows the sandbox to be escaped by overriding `util.inspect.custom`. Since we do not allow `require` to be called inside the sandbox, it is not a concern (banned classes also addresses some, if it not all, usages of this). A unit test proves this out.

The second vulnerability allows a malicious user to escape the sandbox using `Symbol.species`. I don't entirely understand this but banning classes - which are not and should not be used in job code - gives us blanket protection from the vulnerability.

More details about both vulnerabilities are due to be published on August 8th, after which time we may decide to revisit these changes and add more leniency.