### PR TITLE
Fix transform error

### DIFF
--- a/lib/compile/transforms.js
+++ b/lib/compile/transforms.js
@@ -171,14 +171,15 @@ function wrapIIFE() {
 
 // Class statements are now illegal in expressions, as they may expose
 // security vulnerabilities. See https://github.com/OpenFn/core/issues/47
-function banClasses() { 
+function banClasses() {
   return ast => {
     types.visit(ast, {
       visitClassDeclaration: () => {
-        throw new Error('Illegal class statement')
-      }
+        throw new Error('Illegal class statement');
+      },
     });
-  }
+    return ast;
+  };
 }
 
 const defaultTransforms = [


### PR DESCRIPTION
The new banClasses transform failed to return the ast, meaning jobs will break.

This PR fixes that (there are also some formatting changes which are immaterial)